### PR TITLE
Fix overlapping styles and entities in convertToHTML

### DIFF
--- a/src/blockEntities.js
+++ b/src/blockEntities.js
@@ -26,12 +26,18 @@ export default (block, entityMap, entityConverter = converter) => {
 
       const originalText = resultText.substr(entityRange.offset, entityRange.length);
 
-      const converted = getElementHTML(getEntityHTML(entity, originalText), originalText)
+      const entityHTML = getEntityHTML(entity, originalText);
+      const converted = getElementHTML(entityHTML, originalText)
                         || originalText;
+
+      let prefixLength = 0;
+      if (typeof entityHTML === 'object') {
+        prefixLength = entityHTML.start ? entityHTML.start.length : 0;
+      }
 
       const updateLaterMutation = (mutation, mutationIndex) => {
         if (mutationIndex >= index || Object.prototype.hasOwnProperty.call(mutation, 'style')) {
-          return updateMutation(mutation, entityRange.offset, entityRange.length, converted.length);
+          return updateMutation(mutation, entityRange.offset, entityRange.length, converted.length, prefixLength);
         }
         return mutation;
       };

--- a/src/blockEntities.js
+++ b/src/blockEntities.js
@@ -37,7 +37,10 @@ export default (block, entityMap, entityConverter = converter) => {
 
       const updateLaterMutation = (mutation, mutationIndex) => {
         if (mutationIndex >= index || Object.prototype.hasOwnProperty.call(mutation, 'style')) {
-          return updateMutation(mutation, entityRange.offset, entityRange.length, converted.length, prefixLength);
+          return updateMutation(
+            mutation, entityRange.offset, entityRange.length,
+            converted.length, prefixLength
+          );
         }
         return mutation;
       };

--- a/src/encodeBlock.js
+++ b/src/encodeBlock.js
@@ -27,7 +27,7 @@ export default block => {
       resultText += encoded;
 
       const updateForChar = mutation => {
-        return updateMutation(mutation, resultIndex, char.length, encoded.length);
+        return updateMutation(mutation, resultIndex, char.length, encoded.length, 0);
       };
 
       entities = entities.map(updateForChar);

--- a/src/util/updateMutation.js
+++ b/src/util/updateMutation.js
@@ -1,4 +1,6 @@
-export default function updateMutation(mutation, originalOffset, originalLength, newLength, prefixLength) {
+export default function updateMutation(
+  mutation, originalOffset, originalLength, newLength, prefixLength
+) {
   // two cases we can reasonably adjust - disjoint mutations that
   // happen later on where the offset will need to be changed, and
   // mutations that completely contain the new one where we can adjust

--- a/src/util/updateMutation.js
+++ b/src/util/updateMutation.js
@@ -1,4 +1,4 @@
-export default function updateMutation(mutation, originalOffset, originalLength, newLength) {
+export default function updateMutation(mutation, originalOffset, originalLength, newLength, prefixLength) {
   // two cases we can reasonably adjust - disjoint mutations that
   // happen later on where the offset will need to be changed, and
   // mutations that completely contain the new one where we can adjust
@@ -16,6 +16,11 @@ export default function updateMutation(mutation, originalOffset, originalLength,
   ) {
     return Object.assign({}, mutation, {
       length: mutation.length + lengthDiff
+    });
+  }
+  if (originalOffset <= mutation.offset) {
+    return Object.assign({}, mutation, {
+      offset: mutation.offset + prefixLength
     });
   }
 

--- a/src/util/updateMutation.js
+++ b/src/util/updateMutation.js
@@ -1,10 +1,10 @@
 export default function updateMutation(
   mutation, originalOffset, originalLength, newLength, prefixLength
 ) {
-  // two cases we can reasonably adjust - disjoint mutations that
-  // happen later on where the offset will need to be changed, and
+  // three cases we can reasonably adjust - disjoint mutations that
+  // happen later on where the offset will need to be changed,
   // mutations that completely contain the new one where we can adjust
-  // the length.
+  // the length, and mutations that occur partially within the new one.
   const lengthDiff = newLength - originalLength;
 
   if (originalOffset + originalLength <= mutation.offset) {

--- a/test/spec/convertToHTML.js
+++ b/test/spec/convertToHTML.js
@@ -320,6 +320,59 @@ describe('convertToHTML', () => {
     expect(result).toBe('<customtag attribute="value">test</customtag>');
   });
 
+  it('combines styles and entities without overlap', () => {
+    const contentState = buildContentState([
+      {
+        type: 'unstyled',
+        text: 'overlapping styles in entity',
+        styleRanges: [
+          {
+            offset: 0,
+            length: 14,
+            style: 'BOLD'
+          },
+          {
+            offset: 14,
+            length: 14,
+            style: 'ITALIC'
+          }
+        ],
+        entityRanges: [
+          {
+            key: 0,
+            offset: 0,
+            length: 28
+          }
+        ],
+      },
+    ], {
+      0: {
+        type: 'LINK',
+        mutability: 'IMMUTABLE',
+        data: {
+          href: 'http://google.com',
+        }
+      }
+    });
+
+    const result = convertToHTML({
+      entityToHTML: (entity, originalText) => {
+        if (entity.type === 'LINK') {
+          const {data} = entity;
+
+          return {
+            start: `<a href="${data.href}">`,
+            end: '</a>'
+          };
+        }
+
+        return originalText;
+      }
+    })(contentState);
+
+    expect(result).toBe('<p><a href="http://google.com"><strong>overlapping st</strong><em>yles in entity</em></a></p>');
+  });
+
   it('uses JSX for block HTML', () => {
     const contentState = buildContentState([
       {

--- a/test/spec/convertToHTML.js
+++ b/test/spec/convertToHTML.js
@@ -358,7 +358,7 @@ describe('convertToHTML', () => {
     const result = convertToHTML({
       entityToHTML: (entity, originalText) => {
         if (entity.type === 'LINK') {
-          const {data} = entity;
+          const { data } = entity;
 
           return {
             start: `<a href="${data.href}">`,


### PR DESCRIPTION
There is a bug where if a link is partially styled, the conversion to HTML creates invalid HTML markup. For example:

[**Hello** *World*](http://google.com)

will return an html string like:
```
<p><strong><a hr</strong>e<em>f="ht</em>tp://google.com">Hello World</a></p>
```

The expected output is:
```
<p><a href="http://google.com"><strong>Hello</strong> <em>World</em></a></p>
```

This PR fixes the issue by accepting an entity config that returns `{start, end}`. Then it uses the length of `start` as the prefix length. If the inline style mutations start after the original offset, but end before the entity range, we increase the offset by just the prefix length.

The gap in the current logic is that it ignores that an inline style mutation can occur within the entity range, as opposed to only after the entity range.

Includes test from https://github.com/HubSpot/draft-convert/pull/17