### PR TITLE
ZP-1033 fix issue when styling overlaps with a portion of a link

### DIFF
--- a/src/blockEntities.js
+++ b/src/blockEntities.js
@@ -32,12 +32,16 @@ export default (block, entityMap, entityConverter = converter) => {
                         || originalText;
 
       const prefixLength = getElementPrefix(entityHTML);
+      let suffixLength = 0;
+      if (typeof entityHTML === 'object') {
+        suffixLength = entityHTML.end ? entityHTML.end.length : 0;
+      }
 
       const updateLaterMutation = (mutation, mutationIndex) => {
         if (mutationIndex >= index || Object.prototype.hasOwnProperty.call(mutation, 'style')) {
           return updateMutation(
             mutation, entityRange.offset, entityRange.length,
-            converted.length, prefixLength
+            converted.length, prefixLength, suffixLength
           );
         }
         return mutation;

--- a/src/blockEntities.js
+++ b/src/blockEntities.js
@@ -1,7 +1,7 @@
 import updateMutation from './util/updateMutation';
 import rangeSort from './util/rangeSort';
 import getElementHTML from './util/getElementHTML';
-import getElementPrefix from './util/getElementPrefix';
+import getElementTagLength from './util/getElementTagLength';
 
 const converter = (entity = {}, originalText) => {
   return originalText;
@@ -31,11 +31,8 @@ export default (block, entityMap, entityConverter = converter) => {
       const converted = getElementHTML(entityHTML, originalText)
                         || originalText;
 
-      const prefixLength = getElementPrefix(entityHTML);
-      let suffixLength = 0;
-      if (typeof entityHTML === 'object') {
-        suffixLength = entityHTML.end ? entityHTML.end.length : 0;
-      }
+      const prefixLength = getElementTagLength(entityHTML, 'start');
+      const suffixLength = getElementTagLength(entityHTML, 'end');
 
       const updateLaterMutation = (mutation, mutationIndex) => {
         if (mutationIndex >= index || Object.prototype.hasOwnProperty.call(mutation, 'style')) {

--- a/src/encodeBlock.js
+++ b/src/encodeBlock.js
@@ -27,7 +27,7 @@ export default block => {
       resultText += encoded;
 
       const updateForChar = mutation => {
-        return updateMutation(mutation, resultIndex, char.length, encoded.length, 0);
+        return updateMutation(mutation, resultIndex, char.length, encoded.length, 0, 0);
       };
 
       entities = entities.map(updateForChar);

--- a/src/util/getElementTagLength.js
+++ b/src/util/getElementTagLength.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import splitReactElement from './splitReactElement';
 
-export default element => {
+export default (element, type) => {
   if (React.isValidElement(element) && React.Children.count(element.props.children) === 0) {
-    return splitReactElement(element).start.length;
+    return splitReactElement(element)[type].length;
   }
 
   if (typeof element === 'object') {
-    return element.start ? element.start.length : 0;
+    return element[type] ? element[type].length : 0;
   }
 
   return 0;

--- a/src/util/updateMutation.js
+++ b/src/util/updateMutation.js
@@ -1,27 +1,49 @@
 export default function updateMutation(
-  mutation, originalOffset, originalLength, newLength, prefixLength
+  mutation, originalOffset, originalLength, newLength, prefixLength, suffixLength
 ) {
-  // three cases we can reasonably adjust - disjoint mutations that
-  // happen later on where the offset will need to be changed,
-  // mutations that completely contain the new one where we can adjust
-  // the length, and mutations that occur partially within the new one.
   const lengthDiff = newLength - originalLength;
+  const newMutation = {
+    prefixLength,
+    suffixLength
+  };
 
+  // disjoint mutations that happen later on where the offset will need to be changed
   if (originalOffset + originalLength <= mutation.offset) {
-    return Object.assign({}, mutation, {
+    return Object.assign(newMutation, mutation, {
       offset: mutation.offset + lengthDiff
     });
   }
+
+  // mutation that completely contains the new one, in which case we can just adjust the length
   if (
     originalOffset >= mutation.offset
     && originalOffset + originalLength <= mutation.offset + mutation.length
   ) {
-    return Object.assign({}, mutation, {
+    return Object.assign(newMutation, mutation, {
       length: mutation.length + lengthDiff
     });
   }
-  if (originalOffset <= mutation.offset) {
-    return Object.assign({}, mutation, {
+
+  // mutation that starts from before the new one and contains only a portion of the new one
+  if (originalOffset > mutation.offset
+    && mutation.offset + mutation.length < originalOffset + originalLength) {
+    return Object.assign(newMutation, mutation, {
+      length: mutation.length + prefixLength
+    });
+  }
+
+  // mutation that starts within the new one and extends beyond
+  if (originalOffset < mutation.offset
+    && mutation.offset + mutation.length > originalOffset + originalLength) {
+    return Object.assign(newMutation, mutation, {
+      offset: mutation.offset + prefixLength,
+      length: mutation.length + suffixLength
+    });
+  }
+
+  // mutations that occur partially within the new one.
+  if (originalOffset <= mutation.offset && mutation.offset <= originalOffset + originalLength) {
+    return Object.assign(newMutation, mutation, {
       offset: mutation.offset + prefixLength
     });
   }

--- a/test/spec/convertToHTML.js
+++ b/test/spec/convertToHTML.js
@@ -320,42 +320,8 @@ describe('convertToHTML', () => {
     expect(result).toBe('<customtag attribute="value">test</customtag>');
   });
 
-  it('combines styles and entities without overlap', () => {
-    const contentState = buildContentState([
-      {
-        type: 'unstyled',
-        text: 'overlapping styles in entity',
-        styleRanges: [
-          {
-            offset: 0,
-            length: 14,
-            style: 'BOLD'
-          },
-          {
-            offset: 14,
-            length: 14,
-            style: 'ITALIC'
-          }
-        ],
-        entityRanges: [
-          {
-            key: 0,
-            offset: 0,
-            length: 28
-          }
-        ],
-      },
-    ], {
-      0: {
-        type: 'LINK',
-        mutability: 'IMMUTABLE',
-        data: {
-          href: 'http://google.com',
-        }
-      }
-    });
-
-    const result = convertToHTML({
+  describe('combine styles and entities', () => {
+    const convertToHTMLProps = {
       entityToHTML: (entity, originalText) => {
         if (entity.type === 'LINK') {
           const { data } = entity;
@@ -368,9 +334,248 @@ describe('convertToHTML', () => {
 
         return originalText;
       }
-    })(contentState);
+    };
 
-    expect(result).toBe('<p><a href="http://google.com"><strong>overlapping st</strong><em>yles in entity</em></a></p>');
+    it('combines styles and entities without overlap', () => {
+      const contentState = buildContentState([
+        {
+          type: 'unstyled',
+          text: 'overlapping styles in entity',
+          styleRanges: [
+            {
+              offset: 0,
+              length: 14,
+              style: 'BOLD'
+            },
+            {
+              offset: 14,
+              length: 14,
+              style: 'ITALIC'
+            }
+          ],
+          entityRanges: [
+            {
+              key: 0,
+              offset: 0,
+              length: 28,
+              prefixLength: '<a href="http://google.com">'.length,
+              suffixLength: '</a>'.length
+            }
+          ],
+        },
+      ], {
+        0: {
+          type: 'LINK',
+          mutability: 'IMMUTABLE',
+          data: {
+            href: 'http://google.com',
+          }
+        }
+      });
+
+      const result = convertToHTML(convertToHTMLProps)(contentState);
+
+      expect(result).toBe('<p><a href="http://google.com"><strong>overlapping st</strong><em>yles in entity</em></a></p>');
+    });
+
+    it('combines overlapping styles and entities', () => {
+      const contentState = buildContentState([
+        {
+          type: 'unstyled',
+          text: 'overlapping styles in entity',
+          styleRanges: [
+            {
+              offset: 0,
+              length: 14,
+              style: 'BOLD'
+            },
+            {
+              offset: 12,
+              length: 14,
+              style: 'ITALIC'
+            }
+          ],
+          entityRanges: [
+            {
+              key: 0,
+              offset: 0,
+              length: 28,
+              prefixLength: '<a href="http://google.com">'.length,
+              suffixLength: '</a>'.length
+            }
+          ],
+        },
+      ], {
+        0: {
+          type: 'LINK',
+          mutability: 'IMMUTABLE',
+          data: {
+            href: 'http://google.com',
+          }
+        }
+      });
+
+      const result = convertToHTML(convertToHTMLProps)(contentState);
+
+      expect(result).toBe('<p><a href="http://google.com"><strong>overlapping </strong><em><strong>st</strong>yles in enti</em>ty</a></p>');
+    });
+
+    it('combines styles and entities when intersecting with no style to left', () => {
+      const contentState = buildContentState([
+        {
+          type: 'unstyled',
+          text: 'overlapping styles in entity',
+          styleRanges: [
+            {
+              offset: 0,
+              length: 14,
+              style: 'BOLD'
+            }
+          ],
+          entityRanges: [
+            {
+              key: 0,
+              offset: 12,
+              length: 6,
+              prefixLength: '<a href="http://google.com">'.length,
+              suffixLength: '</a>'.length
+            }
+          ],
+        },
+      ], {
+        0: {
+          type: 'LINK',
+          mutability: 'IMMUTABLE',
+          data: {
+            href: 'http://google.com',
+          }
+        }
+      });
+
+      const result = convertToHTML(convertToHTMLProps)(contentState);
+
+      expect(result).toBe('<p><strong>overlapping </strong><a href="http://google.com"><strong>st</strong>yles</a> in entity</p>');
+    });
+
+    it('combines styles and entities when intersecting with no style text to right', () => {
+      const contentState = buildContentState([
+        {
+          type: 'unstyled',
+          text: 'overlapping styles in entity',
+          styleRanges: [
+            {
+              offset: 14,
+              length: 14,
+              style: 'BOLD'
+            }
+          ],
+          entityRanges: [
+            {
+              key: 0,
+              offset: 12,
+              length: 6,
+              prefixLength: '<a href="http://google.com">'.length,
+              suffixLength: '</a>'.length
+            }
+          ],
+        },
+      ], {
+        0: {
+          type: 'LINK',
+          mutability: 'IMMUTABLE',
+          data: {
+            href: 'http://google.com',
+          }
+        }
+      });
+
+      const result = convertToHTML(convertToHTMLProps)(contentState);
+
+      expect(result).toBe('<p>overlapping <a href="http://google.com">st<strong>yles</strong></a><strong> in entity</strong></p>');
+    });
+
+    it('combines styles and entities when intersection with no style text to right and left', () => {
+      const contentState = buildContentState([
+        {
+          type: 'unstyled',
+          text: 'overlapping styles in entity',
+          styleRanges: [
+            {
+              offset: 0,
+              length: 14,
+              style: 'BOLD'
+            },
+            {
+              offset: 16,
+              length: 12,
+              style: 'BOLD'
+            }
+          ],
+          entityRanges: [
+            {
+              key: 0,
+              offset: 12,
+              length: 6,
+              prefixLength: '<a href="http://google.com">'.length,
+              suffixLength: '</a>'.length
+            }
+          ],
+        },
+      ], {
+        0: {
+          type: 'LINK',
+          mutability: 'IMMUTABLE',
+          data: {
+            href: 'http://google.com',
+          }
+        }
+      });
+
+      const result = convertToHTML(convertToHTMLProps)(contentState);
+
+      expect(result).toBe('<p><strong>overlapping </strong><a href="http://google.com"><strong>st</strong>yl<strong>es</strong></a><strong> in entity</strong></p>');
+    });
+
+    it('combines overlapping styles and entities when intersecting with no style', () => {
+      const contentState = buildContentState([
+        {
+          type: 'unstyled',
+          text: 'overlapping styles in entity',
+          styleRanges: [
+            {
+              offset: 0,
+              length: 14,
+              style: 'BOLD'
+            },
+            {
+              offset: 10,
+              length: 14,
+              style: 'ITALIC'
+            }
+          ],
+          entityRanges: [
+            {
+              key: 0,
+              offset: 12,
+              length: 6,
+              prefixLength: '<a href="http://google.com">'.length,
+              suffixLength: '</a>'.length
+            }
+          ],
+        },
+      ], {
+        0: {
+          type: 'LINK',
+          mutability: 'IMMUTABLE',
+          data: {
+            href: 'http://google.com',
+          }
+        }
+      });
+
+      const result = convertToHTML(convertToHTMLProps)(contentState);
+      expect(result).toBe('<p><strong>overlappin<em>g </em></strong><a href="http://google.com"><em><strong>st</strong>yles</em></a><em> in en</em>tity</p>');
+    });
   });
 
   it('combines styles and entities without overlap using react to conver to HTML', () => {


### PR DESCRIPTION
There is a bug where if a link is partially styled and intersects with non styled text. 

For example:

**overlapping** [**st**yles](http://google.com) in entity

should result to html:
```
<p><strong>overlapping </strong><a href="http://google.com"><strong>st</strong>yles</a> in entity</p>
```